### PR TITLE
Support 2021.3 platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ Usage
 
 Changelog
 ---------
+### [v1.16](https://github.com/sadv1r/ansible-vault-editor-idea-plugin/tree/v1.16) (2021-12-01)
+
+* IntelliJ Platform 2021.3 support
 
 ### [v1.15](https://github.com/sadv1r/ansible-vault-editor-idea-plugin/tree/v1.15) (2021-07-12)
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group 'ru.sadv1r'
-version '1.15'
+version '1.16'
 
 repositories {
     mavenCentral()
@@ -43,7 +43,7 @@ intellij {
 
 patchPluginXml {
     sinceBuild = "191.1"
-    untilBuild = "212.*"
+    untilBuild = "213.*"
 
     pluginDescription = """
 Helps you create and edit Ansible Vaults
@@ -64,6 +64,12 @@ Helps you create and edit Ansible Vaults
 """
 
     changeNotes = """
+<a href="https://github.com/sadv1r/ansible-vault-editor-idea-plugin/tree/v1.16"><b>v1.16</b></a> (2021-12-01)
+<br/>
+<ul>
+    <li>IntelliJ Platform 2021.3 support</li>
+</ul>
+<br/>
 <a href="https://github.com/sadv1r/ansible-vault-editor-idea-plugin/tree/v1.15"><b>v1.15</b></a> (2021-07-12)
 <br/>
 <ul>


### PR DESCRIPTION
Fixes #121 
P.S. Maybe it should not have such strict boundaries for "untilBuild" at all? I guess it would be better just to break the plugin in case of breaking changes in the IntelliJ platform rather than breaking after every single IntelliJ platform update.