### PR TITLE
Fix default to opt-out of bundling Kotlin standard library in plugin …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+- Fix default to opt-out of bundling Kotlin standard library in plugin distribution
+
+### Changed
+- Plugin size significantly reduced
 
 ## [1.18]
 ### Added

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,6 @@
-pluginVersion = 1.18
+pluginVersion=1.19
+
+# Opt-out flag for bundling Kotlin standard library -> https://plugins.jetbrains.com/docs/intellij/kotlin.html#kotlin-standard-library
+kotlin.stdlib.default.dependency=false
 
 kotlin.test.infer.jvm.variant=false


### PR DESCRIPTION
…distribution