### PR TITLE
ANSIBLE_VAULT_PASSWORD_FILE as text file in Windows OS

### DIFF
--- a/src/main/kotlin/ru/sadv1r/idea/plugin/ansible/vault/editor/Vault.kt
+++ b/src/main/kotlin/ru/sadv1r/idea/plugin/ansible/vault/editor/Vault.kt
@@ -70,15 +70,20 @@ abstract class Vault {
 
                 val defaultPassword = if (file.canExecute()) {
                     val vaultId = getVaultId()
-                    val process = if (vaultId == null) {
-                        Runtime.getRuntime().exec(file.absolutePath)
-                    } else {
-                        Runtime.getRuntime().exec(arrayOf(file.absolutePath, "--vault-id", vaultId))
-                    }
 
-                    process.waitFor(10, TimeUnit.SECONDS)
-                    val reader = BufferedReader(InputStreamReader(process.inputStream, Charsets.UTF_8))
-                    reader.readText()
+                    try {
+                        val process = if (vaultId == null) {
+                            Runtime.getRuntime().exec(file.absolutePath)
+                        } else {
+                            Runtime.getRuntime().exec(arrayOf(file.absolutePath, "--vault-id", vaultId))
+                        }
+
+                        process.waitFor(10, TimeUnit.SECONDS)
+                        val reader = BufferedReader(InputStreamReader(process.inputStream, Charsets.UTF_8))
+                        reader.readText()
+                    } catch (e: Exception) {
+                        file.readText(Charsets.UTF_8)
+                    }
                 } else {
                     file.readText(Charsets.UTF_8)
                 }


### PR DESCRIPTION
PR will allow to use ANSIBLE_VAULT_PASSWORD_FILE env variable pointing to text file on Windows OS.

Right now, plugin checks for file execution permission using: `file.canExecute()`, which won`t work on Windows.
Additional try...catch statement is solving that problem.

Tested on W10.

