### PR TITLE
Fixed wrong line separators: '\r\n'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Removed
 
 ### Fixed
+- Wrong line separators: '\r\n'
 
 ### Security
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-pluginVersion=1.20
+pluginVersion=1.21
 
 # Opt-out flag for bundling Kotlin standard library -> https://plugins.jetbrains.com/docs/intellij/kotlin.html#kotlin-standard-library
 kotlin.stdlib.default.dependency=false

--- a/src/main/kotlin/ru/sadv1r/idea/plugin/ansible/vault/editor/ui/VaultEditorDialog.kt
+++ b/src/main/kotlin/ru/sadv1r/idea/plugin/ansible/vault/editor/ui/VaultEditorDialog.kt
@@ -5,6 +5,7 @@ import com.intellij.openapi.editor.Document
 import com.intellij.openapi.editor.EditorFactory
 import com.intellij.openapi.editor.colors.EditorColorsManager
 import com.intellij.openapi.editor.ex.EditorEx
+import com.intellij.openapi.editor.impl.EditorFactoryImpl
 import com.intellij.openapi.fileTypes.UnknownFileType
 import com.intellij.openapi.ui.DialogWrapper
 import ru.sadv1r.idea.plugin.ansible.vault.editor.Vault
@@ -29,10 +30,11 @@ class VaultEditorDialog(
     }
 
     override fun createCenterPanel(): JComponent {
-        val editorFactory = EditorFactory.getInstance()
+        val editorFactory = EditorFactory.getInstance() as EditorFactoryImpl
 
         decryptedDocument = editorFactory.createDocument(
-            decryptedDocumentData.toString(Charsets.UTF_8)
+            decryptedDocumentData.toString(Charsets.UTF_8),
+            true, false
         )
         decryptedDocument.setReadOnly(false)
         editor = editorFactory.createEditor(decryptedDocument) as EditorEx


### PR DESCRIPTION
For some reason, EditorFactory has no method with control parameter for \r validity and we need to cast EditorFactory to EditorFactoryImpl.
We can do it safely, for example:
```kotlin
    decryptedDocument = (editorFactory as? EditorFactoryImpl)?.createDocument(
        decryptedDocumentData.toString(Charsets.UTF_8),
        true, false
    ) ?: editorFactory.createDocument(
        decryptedDocumentData.toString(Charsets.UTF_8)
    )
```
But it's a pretty old API and JetBrains is just using cast everywhere, so I did the same