### PR TITLE
GitHub Actions: Replace gradle/gradle-build-action@v2 with gradle/actions/setup-gradle@v3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
           java-version: 11
 
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v3
         with:
           gradle-home-cache-cleanup: true
 
@@ -90,7 +90,7 @@ jobs:
           java-version: 11
 
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v3
         with:
           gradle-home-cache-cleanup: true
 
@@ -164,7 +164,7 @@ jobs:
           java-version: 11
 
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v3
         with:
           gradle-home-cache-cleanup: true
 


### PR DESCRIPTION
Replaces gradle-build-action renamed to actions/setup-gradle as specified in https://github.com/gradle/gradle-build-action/releases/tag/v3.0.0 to fix warning: `Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: gradle/gradle-build-action@v2`