### PR TITLE
Remove gradle/wrapper-validation-action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,9 +20,6 @@ jobs:
       - name: Fetch Sources
         uses: actions/checkout@v4
 
-      - name: Gradle Wrapper Validation
-        uses: gradle/wrapper-validation-action@v1.1.0
-
       - name: Setup Java
         uses: actions/setup-java@v4
         with:


### PR DESCRIPTION
This step is no longer necessary, as setup-gradle@v4 [will now handle the same wrapper validation](https://github.com/gradle/actions/blob/main/docs/setup-gradle.md#gradle-wrapper-validation)