### PR TITLE
Remove redundant `gradle-home-cache-cleanup` configuration from GitHub Actions workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,8 +28,6 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
-        with:
-          gradle-home-cache-cleanup: true
 
       - name: Export Properties
         id: properties
@@ -88,8 +86,6 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
-        with:
-          gradle-home-cache-cleanup: true
 
       - name: Run Tests
         run: ./gradlew test
@@ -168,8 +164,6 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
-        with:
-          gradle-home-cache-cleanup: true
 
       - name: Setup Plugin Verifier IDEs Cache
         uses: actions/cache@v4


### PR DESCRIPTION
Remove redundant `gradle-home-cache-cleanup` configuration from GitHub Actions workflow because it is performed by default in gradle/actions/setup-gradle@v4

https://github.com/gradle/actions/blob/main/docs/deprecation-upgrade-guide.md#the-gradle-home-cache-cleanup-input-parameter-has-been-replaced-by-cache-cleanup