### PR TITLE
Upgrade Gradle wrapper to 8.14.3

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Summary
- Upgrades Gradle wrapper to 8.14.3

## Changes
- Updated `gradle/wrapper/gradle-wrapper.properties`

## Test plan
- [x] Build completed successfully
- [x] All tests passed
- [x] No critical warnings or errors