### PR TITLE
Fixed deprecated group declaration syntax in build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
     id 'org.jetbrains.changelog' version '2.4.0'
 }
 
-group 'ru.sadv1r'
+group = 'ru.sadv1r'
 version = properties['pluginVersion']
 
 repositories {


### PR DESCRIPTION
https://docs.gradle.org/8.13/userguide/upgrading_version_8.html#groovy_space_assignment_syntax