### PR TITLE
#280 Set action update thread to BGT for FileEncryptAction and OpenEditorAction

### DIFF
--- a/src/main/kotlin/ru/sadv1r/idea/plugin/ansible/vault/editor/action/FileEncryptAction.kt
+++ b/src/main/kotlin/ru/sadv1r/idea/plugin/ansible/vault/editor/action/FileEncryptAction.kt
@@ -1,5 +1,6 @@
 package ru.sadv1r.idea.plugin.ansible.vault.editor.action
 
+import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.PlatformDataKeys
@@ -9,10 +10,15 @@ import ru.sadv1r.idea.plugin.ansible.vault.editor.ui.CreatePropertyVaultPassword
 
 class FileEncryptAction : AnAction() {
 
+    override fun getActionUpdateThread(): ActionUpdateThread {
+        return ActionUpdateThread.BGT
+    }
+
     override fun update(e: AnActionEvent) {
         val document = e.getData(PlatformDataKeys.EDITOR)?.document
 
-        e.presentation.isEnabledAndVisible = document?.textLength != 0 && document?.text?.startsWith(VaultInfo.MAGIC_PART_DATA)?.not() ?: false
+        e.presentation.isEnabledAndVisible =
+            document?.textLength != 0 && document?.text?.startsWith(VaultInfo.MAGIC_PART_DATA)?.not() ?: false
     }
 
     override fun actionPerformed(e: AnActionEvent) {

--- a/src/main/kotlin/ru/sadv1r/idea/plugin/ansible/vault/editor/action/OpenEditorAction.kt
+++ b/src/main/kotlin/ru/sadv1r/idea/plugin/ansible/vault/editor/action/OpenEditorAction.kt
@@ -1,5 +1,6 @@
 package ru.sadv1r.idea.plugin.ansible.vault.editor.action
 
+import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.PlatformDataKeys
@@ -7,6 +8,10 @@ import ru.sadv1r.ansible.vault.crypto.VaultInfo
 import ru.sadv1r.idea.plugin.ansible.vault.editor.FileVault
 
 class OpenEditorAction : AnAction() {
+
+    override fun getActionUpdateThread(): ActionUpdateThread {
+        return ActionUpdateThread.BGT
+    }
 
     override fun update(e: AnActionEvent) {
         val document = e.getData(PlatformDataKeys.EDITOR)?.document


### PR DESCRIPTION
Fixes deprecated API usage by implementing getActionUpdateThread() in action classes to explicitly specify Background Thread (BGT) for action updates.

Both actions perform lightweight read-only document checks in their update() methods and don't require write access to the PSI or document, making BGT the appropriate choice for better IDE responsiveness