### PR TITLE
Fixed deprecated Runtime.exec(String) in getPasswordFromFile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Changed
 
-- Change since build to `242` (2024.2)
+- Changed since build to `242` (2024.2)
 - Upgraded IntelliJ Platform Gradle Plugin from 1.17.4 to 2.10.5
 
 ### Deprecated
@@ -14,6 +14,8 @@
 ### Removed
 
 ### Fixed
+
+- Fixed handling of password file paths containing spaces
 
 ### Security
 

--- a/src/main/kotlin/ru/sadv1r/idea/plugin/ansible/vault/editor/AnsibleConfigReader.kt
+++ b/src/main/kotlin/ru/sadv1r/idea/plugin/ansible/vault/editor/AnsibleConfigReader.kt
@@ -26,7 +26,7 @@ private fun getPasswordFromFile(vaultId: String?): String? {
         return if (file.canExecute()) {
             try {
                 val process = if (vaultId == null) {
-                    Runtime.getRuntime().exec(file.absolutePath)
+                    Runtime.getRuntime().exec(arrayOf(file.absolutePath))
                 } else {
                     Runtime.getRuntime().exec(arrayOf(file.absolutePath, "--vault-id", vaultId))
                 }


### PR DESCRIPTION
Replace deprecated exec(String) with exec(String[]) to properly handle file paths with spaces and fix deprecation warning.

See: https://bugs.openjdk.org/browse/JDK-8276412