### PR TITLE
Fixed deprecated ExpectedException.none() in VaultHandlerTest

### DIFF
--- a/src/test/java/ru/sadv1r/ansible/vault/VaultHandlerTest.java
+++ b/src/test/java/ru/sadv1r/ansible/vault/VaultHandlerTest.java
@@ -1,15 +1,14 @@
 package ru.sadv1r.ansible.vault;
 
 import org.apache.commons.io.IOUtils;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 @SuppressWarnings("ConstantConditions")
 public class VaultHandlerTest {
@@ -21,9 +20,6 @@ public class VaultHandlerTest {
             "\n" +
             "db:\n" +
             "    pass: qwerty";
-
-    @Rule
-    public final ExpectedException exceptionRule = ExpectedException.none();
 
     @Test
     public void decrypt() throws IOException {
@@ -43,11 +39,13 @@ public class VaultHandlerTest {
 
     @Test
     public void decryptInvalidVault() throws IOException {
-        exceptionRule.expect(IOException.class);
-        exceptionRule.expectMessage("HMAC Digest doesn't match - possibly it's the wrong password.");
         InputStream encodedStream = getClass().getClassLoader().getResourceAsStream("test-vault.yml");
         String encryptedValue = IOUtils.toString(encodedStream, StandardCharsets.UTF_8);
-        VaultHandler.decrypt(encryptedValue, TEST_WRONG_PASSWORD);
+
+        IOException exception = assertThrows(IOException.class, () ->
+                VaultHandler.decrypt(encryptedValue, TEST_WRONG_PASSWORD)
+        );
+        assertEquals("HMAC Digest doesn't match - possibly it's the wrong password.", exception.getMessage());
     }
 
 }


### PR DESCRIPTION
Replace the deprecated rule with the modern assertThrows approach to fix the deprecation warning