### PR TITLE
Bump actions/upload-artifact to v6 (match template)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
           echo "filename=${FILENAME:0:-4}" >> $GITHUB_OUTPUT
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ steps.artifact.outputs.filename }}
           path: ./build/distributions/content/*/*
@@ -78,7 +78,7 @@ jobs:
 
       - name: Collect Tests Result
         if: failure()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: tests-result
           path: ${{ github.workspace }}/build/reports/tests
@@ -153,7 +153,7 @@ jobs:
 
       - name: Collect Plugin Verifier Result
         if: always()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: pluginVerifier-result
           path: ${{ github.workspace }}/build/reports/pluginVerifier


### PR DESCRIPTION
Bumps `actions/upload-artifact` from v5 to v6 to match `JetBrains/intellij-platform-plugin-template` `main` (which is on v6, not yet on v7).

Supersedes #397, which proposed v5 → v7. Dependabot will refile for v6 → v7 once this merges and the template repo catches up.

## Notes

- v6 requires Node.js 24 (`runs.using: node24`) and Actions Runner 2.327.1+. GitHub-hosted runners satisfy this; self-hosted runners would need updating, but this project doesn't use any.