### PR TITLE
Bump org.jetbrains.intellij.platform to 2.14.0 (match template)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,7 @@ opentest4j = "1.3.0"
 
 # plugins
 changelog = "2.5.0"
-intellijPlatform = "2.10.5"
+intellijPlatform = "2.14.0"
 kotlin = "2.2.21"
 
 [libraries]


### PR DESCRIPTION
Bumps `org.jetbrains.intellij.platform` from 2.10.5 to **2.14.0** to match `main` of [JetBrains/intellij-platform-plugin-template](https://github.com/JetBrains/intellij-platform-plugin-template) (in `settings.gradle.kts`).

Supersedes the partial path of #395 (which proposed jumping straight to 2.15.0). After this PR merges, `@dependabot recreate` will be posted on #395 so it refiles for the remaining 2.14.0 → 2.15.0 delta.